### PR TITLE
Allow to override build date

### DIFF
--- a/MakeTools/prep.sh
+++ b/MakeTools/prep.sh
@@ -81,6 +81,7 @@ then
 	exit 1
 fi
 
+[[ $SOURCE_DATE_EPOCH ]] && DATE=`date -u -d "@$SOURCE_DATE_EPOCH" -Iseconds`
 DATE=${DATE:-"`date +'%m/%d/%y %H:%M'`"}
 
 if [ "$#" = 1 ]


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call only works with GNU date.

Also use UTC to be independent of timezones.
And use ISO date format as the only proper way to unambiguously
represent a date.