### PR TITLE
Fix bashism in MpiApps/apps scripts.

### DIFF
--- a/MpiApps/apps/prepare_run
+++ b/MpiApps/apps/prepare_run
@@ -104,7 +104,7 @@ fi
 
 MIN_PROCESSES=${MIN_PROCESSES:-2}
 MULT_PROCESSES=${MULT_PROCESSES:-1}
-if [ z"$NUM_PROCESSES" == zall ]
+if [ z"$NUM_PROCESSES" = zall ]
 then
 	# skip comment and blank lines
 	NUM_PROCESSES=$(cat $MPI_HOSTS|egrep -v '^[[:space:]]*#'|egrep -v '^[[:space:]]*$'|wc -l)

--- a/MpiApps/apps/run_allhfilatency
+++ b/MpiApps/apps/run_allhfilatency
@@ -47,7 +47,7 @@ MINUTES=1
 VERBOSE=
 CSV=
 
-function usage {
+usage() {
 	echo
 	echo "$0 is a specialized stress test for large fabrics. It iterates through"
 	echo "every possible pairing of HCAs and performs a latency test on each"
@@ -124,7 +124,7 @@ if [ $# -ge 1 ]; then
 fi
 shift
 if [ $# -ge 1 ]; then
-	if [ $1 == "infinite" ]; then
+	if [ $1 = "infinite" ]; then
 		MINUTES=0
 	elif [ $1 -eq $1 ]; then
 		MINUTES=$1

--- a/MpiApps/apps/run_app
+++ b/MpiApps/apps/run_app
@@ -103,7 +103,7 @@ MONITOR_FILE=
 CODE_FILES=
 
 loop=n
-if [ x"$1" == "x-l" ]
+if [ x"$1" = "x-l" ]
 then
 	loop=y
 	shift
@@ -126,7 +126,7 @@ else
 	chassis_arg=
 fi
 
-if [ "x$APP" == "x" ]
+if [ "x$APP" = "x" ]
 then
 	# get command name part of APP_CMD (eg. remove arguments)
 	app=`(set $APP_CMD; echo $1)`

--- a/MpiApps/apps/run_cabletest
+++ b/MpiApps/apps/run_cabletest
@@ -52,7 +52,7 @@ MINSIZE=4194304
 MAXSIZE=4194304
 VERBOSE=
 
-function usage {
+usage() {
 	echo
 	echo "$0 is a specialized stress test for large fabrics. It groups"
 	echo "MPI ranks into sets which are tested against other members of the set."
@@ -139,7 +139,7 @@ GROUP_SIZE=$((GROUP_SIZE * PROCS_PER_NODE))
 export MPI_HOSTS=$MPI_GROUP_HOSTS
 
 if [ $# -ge 1 ] ; then 
-	if [ $1 == "infinite" ]; then
+	if [ $1 = "infinite" ]; then
 		MINUTES=0
 	elif [ $1 -eq $1 ]; then
 		MINUTES=$1

--- a/MpiApps/apps/run_osu
+++ b/MpiApps/apps/run_osu
@@ -38,7 +38,7 @@ MPICH_PREFIX=${MPICH_PREFIX:-`cat .prefix 2>/dev/null`}
 
 trap "exit 1" SIGHUP SIGTERM SIGINT
 
-if [ -z "$1" -o "$1" == "-h" ]
+if [ -z "$1" -o "$1" = "-h" ]
 then 
 	echo " Usage: run_osu <number_of_processes> <command> <arg1> <arg2>...<argn> "
 	echo " For example: ./run_osu 2 osu_allgatherv"


### PR DESCRIPTION
Fix #12 
Some scripts in MpiApps/apps shbang /bin/sh but use bash syntax.
Change this to bourne shell syntax.

  * Use = instead of ==
  * Use func() {} instead of function func {}.