### PR TITLE
Fix spelling errors in binaries and manpages.

### DIFF
--- a/Esm/ib/src/config/fm_xml.c
+++ b/Esm/ib/src/config/fm_xml.c
@@ -249,7 +249,7 @@ int getXMLConfigData(uint8_t *buffer, uint32_t bufflen, uint32_t *filelen)
 		buffer[index++] = nextByte;
 		if (index >= bufflen) {
 			*filelen = 0;
-			IB_LOG_ERROR("Buffer overrun geting ESM config file! rc:",0x0020);
+			IB_LOG_ERROR("Buffer overrun getting ESM config file! rc:",0x0020);
 			fclose(file);
 			return -1;
 		}

--- a/IbaTools/man/opascpall.manPage
+++ b/IbaTools/man/opascpall.manPage
@@ -109,7 +109,7 @@ opascpall a b c /root/tools/
 .br
 
 .br
-# copy to an explitly specified set of hosts
+# copy to an explicitly specified set of hosts
 .br
 opascpall -h \[aq]arwen elrond\[aq] a b c /root/tools
 .br

--- a/IbaTools/opapaquery/opapaquery.c
+++ b/IbaTools/opapaquery/opapaquery.c
@@ -1197,7 +1197,7 @@ void usage(void)
 	fprintf(stderr, "           0x00000040   6     Link Error Downed\n");
 	fprintf(stderr, "           0x00000020   5     Uncorrectable Errors\n");
 	fprintf(stderr, " \n");
- 	fprintf(stderr, "         select bits for clrVfPortCounters (0 is least signficant (rightmost))\n");
+ 	fprintf(stderr, "         select bits for clrVfPortCounters (0 is least significant (rightmost))\n");
 	fprintf(stderr, "           mask        bit location \n");
 	fprintf(stderr, "           0x80000000  31     VLXmitData \n");
 	fprintf(stderr, "           0x40000000  30     VLRcvData \n");
@@ -1213,7 +1213,7 @@ void usage(void)
 	fprintf(stderr,	"           0x00100000  20     VLXmitWaitData\n");
 	fprintf(stderr, "           0x00080000  19     VLRcvBubble \n");
 	fprintf(stderr, "           0x00040000  18     VLMarkFECN\n");
-	fprintf(stderr, "           Bits 17-0 reseved\n");
+	fprintf(stderr, "           Bits 17-0 reserved\n");
  	fprintf(stderr, "     -f/--focus         - focus select value for getting focus ports\n");
  	fprintf(stderr, "         focus select values:\n");
 	fprintf(stderr, "           unexpclrport  - lists unexpectedly cleared ports - LID ordered\n");          // STL_PA_SELECT_UNEXP_CLR_PORT         0x00010101

--- a/opamgt/src/omgt_oob_ssl.c
+++ b/opamgt/src/omgt_oob_ssl.c
@@ -386,7 +386,7 @@ void* omgt_oob_ssl_connect(struct omgt_port *port, void *context, int serverfd)
 		// is not presented by the server the connection will be rejected.
 		if (!(cert = SSL_get_peer_certificate(session))) {
 			status = OMGT_STATUS_NOT_FOUND;
-			OMGT_OUTPUT_ERROR(port, "server has no certifcate to verfiy\n");
+			OMGT_OUTPUT_ERROR(port, "server has no certificate to verify\n");
 		} else {
 			long result;
 

--- a/opamgt/src/opamgt_sa_notice.c
+++ b/opamgt/src/opamgt_sa_notice.c
@@ -219,7 +219,7 @@ OMGT_STATUS_T omgt_sa_get_notice_report(struct omgt_port *port, STL_NOTICE **not
 		/* Otherwise error */
 		} else {
 			SA_MAD *samad = (SA_MAD *)&packet->MadData.common;
-			OMGT_OUTPUT_ERROR(port, "Unexpected OOB MAD recieved: %s %s(%s)\n",
+			OMGT_OUTPUT_ERROR(port, "Unexpected OOB MAD received: %s %s(%s)\n",
 				stl_class_str(samad->common.BaseVersion, samad->common.MgmtClass),
 				stl_method_str(samad->common.BaseVersion, samad->common.MgmtClass, samad->common.mr.AsReg8),
 				stl_attribute_str(samad->common.BaseVersion, samad->common.MgmtClass, hton16(samad->common.AttributeID)));


### PR DESCRIPTION
These spelling errors were identified by the lintian tool. They
are present in strings used by log and help messages.

This closes issue #18 .