### PR TITLE
Add Rocky Linux changes (detection/tests) for opa-ff

### DIFF
--- a/CommonInstall/util_init.pl
+++ b/CommonInstall/util_init.pl
@@ -257,6 +257,12 @@ sub os_vendor_version($)
 			$rval = `cat /etc/redhat-release`;
 			$rval =~ m/(\d+).(\d+)/;
 			$rval="ES".$1;
+		} elsif (!system("grep -qi Rocky /etc/redhat-release")) {
+			# Find a number of the form "#.#" and output the portion
+			# to the left of the decimal point.
+			$rval = `cat /etc/redhat-release`;
+			$rval =~ m/(\d+).(\d+)/;
+			$rval="ES".$1;
 		} elsif (!system("grep -qi enterprise /etc/redhat-release")) {
 			# Red Hat Enterprise Linux Server release $a.$b (name)
 			#PR 110926
@@ -304,6 +310,8 @@ sub determine_os_version()
 		$CUR_DISTRO_VENDOR = "redhat";
 	} elsif ( -s "/etc/centos-release" ) {
 		$CUR_DISTRO_VENDOR = "redhat";
+	} elsif ( -s "/etc/rocky-release" ) {
+		$CUR_DISTRO_VENDOR = "redhat";
 	} elsif ( -s "/etc/UnitedLinux-release" ) {
 		$CUR_DISTRO_VENDOR = "UnitedLinux";
 		$NETWORK_CONF_DIR = "/etc/sysconfig/network";
@@ -321,12 +329,14 @@ sub determine_os_version()
 		my %distroVendor = (
 			"rhel" => "redhat",
 			"centos" => "redhat",
+			"rocky" => "redhat",
 			"sles" => "SuSE",
 			"sle_hpc" => "SuSE"
 		);
 		my %network_conf_dir  = (
 			"rhel" => $NETWORK_CONF_DIR,
 			"centos" => $NETWORK_CONF_DIR,
+			"rocky" => $NETWORK_CONF_DIR,
 			"sles" => "/etc/sysconfig/network",
 			"sle_hpc" => "/etc/sysconfig/network"
 		);
@@ -355,6 +365,8 @@ sub determine_os_version()
 		} elsif ($CUR_DISTRO_VENDOR eq "SuSE") {
 			$NETWORK_CONF_DIR = "/etc/sysconfig/network";
 		} elsif ($CUR_DISTRO_VENDOR eq "centos") {
+			$CUR_DISTRO_VENDOR = "redhat";
+		} elsif ($CUR_DISTRO_VENDOR eq "rocky") {
 			$CUR_DISTRO_VENDOR = "redhat";
 		}
 	}

--- a/MakeTools/funcs-ext.sh
+++ b/MakeTools/funcs-ext.sh
@@ -725,6 +725,9 @@ function os_vendor()
             centos)
                 rval=redhat
                 ;;
+            rocky)
+                rval=redhat
+                ;;
             fedora)
                 rval=redhat
                 ;;
@@ -833,6 +836,10 @@ function os_vendor_version()
 		elif grep -qi scientific /etc/redhat-release
 		then
 			# Scientific Linux.
+			rval="ES"`cat /etc/redhat-release | sed -r 's/^.+([[:digit:]])\.([[:digit:]]).+$/\1/'`
+		elif grep -qi rocky /etc/redhat-release
+		then
+			# Rocky Linux.
 			rval="ES"`cat /etc/redhat-release | sed -r 's/^.+([[:digit:]])\.([[:digit:]]).+$/\1/'`
 		else
 			rval=`cat /etc/redhat-release | cut -d' ' -f5`

--- a/OpenIb_Host/update_opa_spec.sh.base
+++ b/OpenIb_Host/update_opa_spec.sh.base
@@ -41,7 +41,7 @@ source ./ff_filegroups.sh
 sed -i "/__RPM_OPASNAPCONFIG1/d" opa.spec
 sed -i "/__RPM_OPASNAPCONFIG2/d" opa.spec
 
-if [ "$id" = "rhel" -o "$id" = "centos" ]
+if [ "$id" = "rhel" -o "$id" = "centos" -o "$id" = "rocky" ]
 then
 	GE_7_4=$(echo "$versionid >= 7.4" | bc)
 	GE_7_5=$(echo "$versionid >= 7.5" | bc)

--- a/get_id_and_versionid.sh
+++ b/get_id_and_versionid.sh
@@ -71,6 +71,10 @@ else
 		then
 			# Scientific Linux.
 			rval=`cat /etc/redhat-release | sed -r 's/^.+([[:digit:]])\.([[:digit:]]).+$/\1.\2/'`
+		elif grep -qi rocky /etc/redhat-release
+		then
+			# Rocky Linux.
+			rval=`cat /etc/redhat-release | sed -r 's/^.+([[:digit:]])\.([[:digit:]]).+$/\1.\2/'`
 		else
 			rval=`cat /etc/redhat-release | cut -d' ' -f5`
 		fi


### PR DESCRIPTION
This PR adds in Rocky Linux to the tests for a Red Hat distribution. Our distribution is failing to build the package thus we needed to make a patch to build and test successfully.

This is a new PR to go against the for-next branch as requested in #27. 