### PR TITLE
Add Circle Linux to detecions and tests

### DIFF
--- a/CommonInstall/util_init.pl
+++ b/CommonInstall/util_init.pl
@@ -224,6 +224,14 @@ sub os_vendor_version($)
 				} else {
 					$rval="ES".$1.$2;
 				}
+			} elsif (!system("grep -qi circle /etc/redhat-release")) {
+				$rval = `cat /etc/redhat-release | cut -d' ' -f4`;
+				$rval =~ m/(\d+).(\d+)/;
+				if ($2 eq "0") {
+					$rval="ES".$1;
+				} else {
+					$rval="ES".$1.$2;
+				}
 			} elsif (!system("grep -qi rocky /etc/redhat-release")) {
 				$rval = `cat /etc/redhat-release | cut -d' ' -f4`;
 				$rval =~ m/(\d+).(\d+)/;
@@ -254,6 +262,12 @@ sub os_vendor_version($)
 			$rval=`cat /etc/redhat-release | cut -d' ' -f7`;
 			chop($rval);
 		} elsif (!system("grep -qi centos /etc/redhat-release")) {
+			# Find a number of the form "#.#" and output the portion
+			# to the left of the decimal point.
+			$rval = `cat /etc/redhat-release`;
+			$rval =~ m/(\d+).(\d+)/;
+			$rval="ES".$1.$2;
+		} elsif (!system("grep -qi circle /etc/redhat-release")) {
 			# Find a number of the form "#.#" and output the portion
 			# to the left of the decimal point.
 			$rval = `cat /etc/redhat-release`;
@@ -318,6 +332,8 @@ sub determine_os_version()
 		$CUR_DISTRO_VENDOR = "redhat";
 	} elsif ( -s "/etc/centos-release" ) {
 		$CUR_DISTRO_VENDOR = "redhat";
+	} elsif ( -s "/etc/circle-release" ) {
+		$CUR_DISTRO_VENDOR = "redhat";
 	} elsif ( -s "/etc/rocky-release" ) {
 		$CUR_DISTRO_VENDOR = "redhat";
 	} elsif ( -s "/etc/UnitedLinux-release" ) {
@@ -337,6 +353,7 @@ sub determine_os_version()
 		my %distroVendor = (
 			"rhel" => "redhat",
 			"centos" => "redhat",
+			"circle" => "redhat",
 			"rocky" => "redhat",
 			"sles" => "SuSE",
 			"sle_hpc" => "SuSE"
@@ -344,6 +361,7 @@ sub determine_os_version()
 		my %network_conf_dir  = (
 			"rhel" => $NETWORK_CONF_DIR,
 			"centos" => $NETWORK_CONF_DIR,
+			"circle" => $NETWORK_CONF_DIR,
 			"rocky" => $NETWORK_CONF_DIR,
 			"sles" => "/etc/sysconfig/network",
 			"sle_hpc" => "/etc/sysconfig/network"
@@ -373,6 +391,8 @@ sub determine_os_version()
 		} elsif ($CUR_DISTRO_VENDOR eq "SuSE") {
 			$NETWORK_CONF_DIR = "/etc/sysconfig/network";
 		} elsif ($CUR_DISTRO_VENDOR eq "centos") {
+			$CUR_DISTRO_VENDOR = "redhat";
+		} elsif ($CUR_DISTRO_VENDOR eq "circle") {
 			$CUR_DISTRO_VENDOR = "redhat";
 		} elsif ($CUR_DISTRO_VENDOR eq "rocky") {
 			$CUR_DISTRO_VENDOR = "redhat";

--- a/MakeTools/funcs-ext.sh
+++ b/MakeTools/funcs-ext.sh
@@ -725,6 +725,9 @@ function os_vendor()
             centos)
                 rval=redhat
                 ;;
+            circle)
+                rval=redhat
+                ;;
             rocky)
                 rval=redhat
                 ;;
@@ -757,6 +760,9 @@ function os_vendor()
 				rval=UnitedLinux
 			fi
 		elif [ $rval = 'centos' ]
+		then
+			rval=redhat
+		elif [ $rval = 'circle' ]
 		then
 			rval=redhat
 		elif [ $rval = 'rocky' ]
@@ -835,6 +841,10 @@ function os_vendor_version()
 		elif grep -qi centos /etc/redhat-release
 		then
 			# CentOS 
+			rval="ES"`cat /etc/redhat-release | sed -r 's/^.+([[:digit:]])\.([[:digit:]]).+$/\1\2/'`
+		elif grep -qi circle /etc/redhat-release
+		then
+			# Circle Linux
 			rval="ES"`cat /etc/redhat-release | sed -r 's/^.+([[:digit:]])\.([[:digit:]]).+$/\1\2/'`
 		elif grep -qi rocky /etc/redhat-release
 		then

--- a/OpenIb_Host/update_mpi_spec.sh
+++ b/OpenIb_Host/update_mpi_spec.sh
@@ -33,7 +33,7 @@
 id=$(./get_id_and_versionid.sh | cut -f1 -d' ')
 versionid=$(./get_id_and_versionid.sh | cut -f2 -d' ')
 
-if [ "$id" = "rhel" -o "$id" = "centos" -o "$id" = "rocky" ]
+if [ "$id" = "rhel" -o "$id" = "centos" -o "$id" = "circle" -o "$id" = "rocky" ]
 then
 	GE_8_0=$(echo "$versionid >= 8.0" | bc)
 	sed -i "s/__RPM_REQ/Requires: atlas/" mpi-apps.spec

--- a/OpenIb_Host/update_opa_spec.sh.base
+++ b/OpenIb_Host/update_opa_spec.sh.base
@@ -41,7 +41,7 @@ source ./ff_filegroups.sh
 sed -i "/__RPM_OPASNAPCONFIG1/d" opa.spec
 sed -i "/__RPM_OPASNAPCONFIG2/d" opa.spec
 
-if [ "$id" = "rhel" -o "$id" = "centos" -o "$id" = "rocky" ]
+if [ "$id" = "rhel" -o "$id" = "centos" -o "$id" = "circle" -o "$id" = "rocky" ]
 then
 	GE_7_4=$(echo "$versionid >= 7.4" | bc)
 	GE_7_5=$(echo "$versionid >= 7.5" | bc)

--- a/get_id_and_versionid.sh
+++ b/get_id_and_versionid.sh
@@ -29,6 +29,9 @@ else
 			elif [ $rval = 'centos' ]
 			then
 				rval=redhat
+			elif [ $rval = 'circle' ]
+			then
+				rval=redhat
 			elif [ $rval = 'rocky' ]
 			then
 				rval=redhat
@@ -69,6 +72,10 @@ else
 		elif grep -qi centos /etc/redhat-release
 		then
 			# CentOS 
+			rval=`cat /etc/redhat-release | sed -r 's/^.+([[:digit:]])\.([[:digit:]]).+$/\1.\2/'`
+		elif grep -qi circle /etc/redhat-release
+		then
+			# Circle Linux 
 			rval=`cat /etc/redhat-release | sed -r 's/^.+([[:digit:]])\.([[:digit:]]).+$/\1.\2/'`
 		elif grep -qi rocky /etc/redhat-release
 		then

--- a/update_opa_spec.sh
+++ b/update_opa_spec.sh
@@ -55,7 +55,7 @@ source ./OpenIb_Host/ff_filegroups.sh
 sed -i "/__RPM_OPASNAPCONFIG1/d" $to
 sed -i "/__RPM_OPASNAPCONFIG2/d" $to
 
-if [ "$id" = "rhel" -o "$id" = "centos" -o "$id" = "rocky" ]
+if [ "$id" = "rhel" -o "$id" = "centos" -o "$id" = "circle" -o "$id" = "rocky" ]
 then
 	GE_7_4=$(echo "$versionid >= 7.4" | bc)
 	GE_7_5=$(echo "$versionid >= 7.5" | bc)


### PR DESCRIPTION
Circle Linux was failed to build opa-ff, we add an patch to let build succussful. this patch add circle linux for a Red Hat distribution.

Signed-off-by: Bella Zhang <bella@cclinux.org>